### PR TITLE
chore: remove unused vulnerable package

### DIFF
--- a/Equinor.SubSurfAppManagementMonitoringNuGet/Equinor.SubSurfAppManagementMonitoringNuGet.csproj
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet/Equinor.SubSurfAppManagementMonitoringNuGet.csproj
@@ -1,31 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <version>1.0.7</version>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackageId>Equinor.SubSurfAppManagementMonitoringNuGet</PackageId>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RepositoryUrl>https://github.com/equinor/SubSurfAppManagementMonitoringNuGet</RepositoryUrl>
+    <PackageDescription>This is a nuget package containing common application management code for subsurface applications.</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <IncludeSymbols>True</IncludeSymbols>
+    <Company>Equinor</Company>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DocumentationFile>bin\Equinor.SubSurfAppManagementMonitoringNuGet.xml</DocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <version>1.0.7</version>
-        <TargetFramework>net8.0</TargetFramework>
-        <PackageId>Equinor.SubSurfAppManagementMonitoringNuGet</PackageId>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <RepositoryUrl>https://github.com/equinor/SubSurfAppManagementMonitoringNuGet</RepositoryUrl>
-        <PackageDescription>This is a nuget package containing common application management code for subsurface applications.</PackageDescription>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
-        <IncludeSymbols>True</IncludeSymbols>
-        <Company>Equinor</Company>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <DocumentationFile>bin\Equinor.SubSurfAppManagementMonitoringNuGet.xml</DocumentationFile>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-      <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-      <PackageReference Include="AspNetCore.HealthChecks" Version="1.0.0" /> 
-      <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" /> 
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
removes seemingly unused package "AspNetCore.HealthChecks" Version="1.0.0" to resolve https://github.com/equinor/SubSurfAppManagementMonitoringNuGet/security/dependabot/2

test package: `dotnet add package Equinor.SubSurfAppManagementMonitoringNuGet --version 3.0.0-preview`