### PR TITLE
feat: AuditActivityProcessor use last x-forwarded-for address

### DIFF
--- a/Equinor.SubSurfAppManagementMonitoringNuGet.UnitTests/AuditActivityProcessorShould.cs
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet.UnitTests/AuditActivityProcessorShould.cs
@@ -70,7 +70,7 @@ public class AuditActivityProcessorShould
     }
 
     [Test]
-    public void SetClientAddressTag_FromFirstXForwardedForHop_WhenHeaderIsPresent()
+    public void SetClientAddressTag_FromLastXForwardedForHop_WhenHeaderIsPresent()
     {
         // Arrange
         var context = new DefaultHttpContext

--- a/Equinor.SubSurfAppManagementMonitoringNuGet.UnitTests/AuditActivityProcessorShould.cs
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet.UnitTests/AuditActivityProcessorShould.cs
@@ -41,7 +41,11 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.TagObjects, Is.Empty, "No tags should be set when HttpContext is null");
+        Assert.That(
+            _activity.TagObjects,
+            Is.Empty,
+            "No tags should be set when HttpContext is null"
+        );
     }
 
     [Test]
@@ -50,10 +54,7 @@ public class AuditActivityProcessorShould
         // Arrange
         var context = new DefaultHttpContext
         {
-            Connection =
-            {
-                RemoteIpAddress = IPAddress.Parse("192.168.1.1")
-            }
+            Connection = { RemoteIpAddress = IPAddress.Parse("192.168.1.1") },
         };
         _mockContextAccessor.Setup(x => x.HttpContext).Returns(context);
 
@@ -62,7 +63,10 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.RemoteIpTag), Is.EqualTo("192.168.1.1"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.RemoteIpTag),
+            Is.EqualTo("192.168.1.1")
+        );
     }
 
     [Test]
@@ -71,11 +75,8 @@ public class AuditActivityProcessorShould
         // Arrange
         var context = new DefaultHttpContext
         {
-            Connection =
-            {
-                RemoteIpAddress = IPAddress.Parse("10.10.10.10")
-            },
-            Request = { Headers = { ["X-Forwarded-For"] = "203.0.113.10, 70.41.3.18" } }
+            Connection = { RemoteIpAddress = IPAddress.Parse("10.10.10.10") },
+            Request = { Headers = { ["X-Forwarded-For"] = "203.0.113.10, 70.41.3.18" } },
         };
         _mockContextAccessor.Setup(x => x.HttpContext).Returns(context);
 
@@ -84,7 +85,10 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.RemoteIpTag), Is.EqualTo("203.0.113.10"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.RemoteIpTag),
+            Is.EqualTo("70.41.3.18")
+        );
     }
 
     [Test]
@@ -93,12 +97,8 @@ public class AuditActivityProcessorShould
         // Arrange
         var context = new DefaultHttpContext
         {
-            Connection =
-            {
-                RemoteIpAddress = IPAddress.Parse("192.168.1.1")
-
-            },
-            Request = { Headers = { ["X-Forwarded-For"] = "   " } }
+            Connection = { RemoteIpAddress = IPAddress.Parse("192.168.1.1") },
+            Request = { Headers = { ["X-Forwarded-For"] = "   " } },
         };
         _mockContextAccessor.Setup(x => x.HttpContext).Returns(context);
 
@@ -107,7 +107,10 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.RemoteIpTag), Is.EqualTo("192.168.1.1"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.RemoteIpTag),
+            Is.EqualTo("192.168.1.1")
+        );
     }
 
     [Test]
@@ -135,7 +138,10 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.UserAgentTag), Is.EqualTo("Mozilla/5.0"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.UserAgentTag),
+            Is.EqualTo("Mozilla/5.0")
+        );
     }
 
     [Test]
@@ -167,7 +173,8 @@ public class AuditActivityProcessorShould
         Assert.That(
             _activity.GetTagItem(AuditActivityProcessor.AuthenticatedUserTag),
             Is.EqualTo("John Doe"),
-            "Name claim should take priority over Email claim");
+            "Name claim should take priority over Email claim"
+        );
     }
 
     [Test]
@@ -187,7 +194,8 @@ public class AuditActivityProcessorShould
         Assert.That(
             _activity.GetTagItem(AuditActivityProcessor.AuthenticatedUserTag),
             Is.EqualTo("john@example.com"),
-            "Email claim should be used as fallback when Name claim is absent");
+            "Email claim should be used as fallback when Name claim is absent"
+        );
     }
 
     [Test]
@@ -206,16 +214,17 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.ApplicationRolesTag), Is.EqualTo("Admin, Editor"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.ApplicationRolesTag),
+            Is.EqualTo("Admin, Editor")
+        );
     }
 
     [Test]
     public void SetUserApplicationRolesTag_AsEmpty_WhenUserHasNoRoles()
     {
         // Arrange
-        var context = CreateAuthenticatedHttpContext(
-            new Claim(ClaimTypes.Name, "John Doe")
-        );
+        var context = CreateAuthenticatedHttpContext(new Claim(ClaimTypes.Name, "John Doe"));
         _mockContextAccessor.Setup(x => x.HttpContext).Returns(context);
 
         // Act
@@ -223,7 +232,10 @@ public class AuditActivityProcessorShould
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.ApplicationRolesTag), Is.EqualTo(""));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.ApplicationRolesTag),
+            Is.EqualTo("")
+        );
     }
 
     [Test]
@@ -246,14 +258,19 @@ public class AuditActivityProcessorShould
     public void SetAuthIdToUnknown_WhenExceptionIsThrown()
     {
         // Arrange
-        _mockContextAccessor.Setup(x => x.HttpContext).Throws(new Exception("Simulated exception"));
+        _mockContextAccessor
+            .Setup(x => x.HttpContext)
+            .Throws(new Exception("Simulated exception"));
 
         // Act
         _activity.Stop();
         _processor.OnEnd(_activity);
 
         // Assert
-        Assert.That(_activity.GetTagItem(AuditActivityProcessor.AuthenticatedUserTag), Is.EqualTo("<unknown>"));
+        Assert.That(
+            _activity.GetTagItem(AuditActivityProcessor.AuthenticatedUserTag),
+            Is.EqualTo("<unknown>")
+        );
     }
 
     private static DefaultHttpContext CreateAuthenticatedHttpContext(params Claim[] claims)

--- a/Equinor.SubSurfAppManagementMonitoringNuGet/Config/AuditActivityProcessor.cs
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet/Config/AuditActivityProcessor.cs
@@ -16,7 +16,6 @@ public class AuditActivityProcessor(IHttpContextAccessor contextAccessor) : Base
     public const string RemoteIpTag = "client.address";
     public const string ApplicationRolesTag = "UserApplicationRoles";
     public const string UserAgentTag = "user-agent";
-    public const string RealIpTag = "x-real-ip";
 
     public override void OnEnd(Activity data)
     {
@@ -29,12 +28,6 @@ public class AuditActivityProcessor(IHttpContextAccessor contextAccessor) : Base
             var ip = !string.IsNullOrWhiteSpace(forwardedFor)
                 ? forwardedFor.Split(',').LastOrDefault()?.Trim()
                 : httpContext.Connection.RemoteIpAddress?.ToString();
-
-            var realIp = httpContext.Request.Headers["X-Real-IP"].FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(realIp))
-            {
-                data.SetTag(RealIpTag, realIp);
-            }
 
             if (!string.IsNullOrWhiteSpace(ip))
             {

--- a/Equinor.SubSurfAppManagementMonitoringNuGet/Config/AuditActivityProcessor.cs
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet/Config/AuditActivityProcessor.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
-using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using OpenTelemetry;
 
 namespace Equinor.SubSurfAppManagementMonitoringNuGet.Config;
@@ -16,17 +16,25 @@ public class AuditActivityProcessor(IHttpContextAccessor contextAccessor) : Base
     public const string RemoteIpTag = "client.address";
     public const string ApplicationRolesTag = "UserApplicationRoles";
     public const string UserAgentTag = "user-agent";
+    public const string RealIpTag = "x-real-ip";
 
     public override void OnEnd(Activity data)
     {
         try
         {
-            if (contextAccessor.HttpContext is not { } httpContext) return;
+            if (contextAccessor.HttpContext is not { } httpContext)
+                return;
 
-            var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].LastOrDefault();
             var ip = !string.IsNullOrWhiteSpace(forwardedFor)
-                ? forwardedFor.Split(',').FirstOrDefault()?.Trim()
+                ? forwardedFor.Split(',').LastOrDefault()?.Trim()
                 : httpContext.Connection.RemoteIpAddress?.ToString();
+
+            var realIp = httpContext.Request.Headers["X-Real-IP"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(realIp))
+            {
+                data.SetTag(RealIpTag, realIp);
+            }
 
             if (!string.IsNullOrWhiteSpace(ip))
             {
@@ -41,18 +49,25 @@ public class AuditActivityProcessor(IHttpContextAccessor contextAccessor) : Base
             if (httpContext.User.Identity?.IsAuthenticated == true)
             {
                 var claims = httpContext.User.Claims.ToList();
-                var userId = claims.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value ??
-                             claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value ??
-                             claims.FirstOrDefault(c => c.Type == ClaimTypes.Upn)?.Value ??
-                             claims.FirstOrDefault(c => string.Equals(c.Type, "upn", StringComparison.OrdinalIgnoreCase))?.Value ??
-                             "<unknown>";
+                var userId =
+                    claims.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value
+                    ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value
+                    ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.Upn)?.Value
+                    ?? claims
+                        .FirstOrDefault(c =>
+                            string.Equals(c.Type, "upn", StringComparison.OrdinalIgnoreCase)
+                        )
+                        ?.Value
+                    ?? "<unknown>";
 
                 data.SetTag(AuthenticatedUserTag, userId);
 
                 var roles = new List<string>();
                 foreach (var identity in httpContext.User.Identities)
                 {
-                    roles.AddRange(identity.Claims.Where(x => x.Type == ClaimTypes.Role).Select(x => x.Value));
+                    roles.AddRange(
+                        identity.Claims.Where(x => x.Type == ClaimTypes.Role).Select(x => x.Value)
+                    );
                 }
 
                 data.SetTag(ApplicationRolesTag, string.Join(", ", roles));


### PR DESCRIPTION
- fix issue where spoofing the client_ip property in application insights was possible.

spoofing example:
```sh
curl -X 'GET' \
  'https://api-forecast-data-inventory-backend-dev.radix.equinor.com/api/v1/health' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer {BearerToken}' \
-H "X-Forwarded-For: 1.2.3.4, 5.6.7.8"
```
requests such as these would show Client_IP as '1.2.3.4' in stead of actual request sender's IP

test version:
```sh
dotnet add package Equinor.SubSurfAppManagementMonitoringNuGet --version 3.0.3-preview
```