### PR TITLE
chore(deps): downgrade Microsoft.OpenApi from 3.9.0 to 2.12.0

### DIFF
--- a/Equinor.SubSurfAppManagementMonitoringNuGet/Equinor.SubSurfAppManagementMonitoringNuGet.csproj
+++ b/Equinor.SubSurfAppManagementMonitoringNuGet/Equinor.SubSurfAppManagementMonitoringNuGet.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.87.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
   <PackageReference Include="OpenTelemetry.Api" Version="1.17.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>


### PR DESCRIPTION
release candidate: 
`dotnet add package Equinor.SubSurfAppManagementMonitoringNuGet --version 3.0.8-rc`
